### PR TITLE
fix: infinite reload loop in dev env

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { ClerkExpressWithAuth } from '@clerk/clerk-sdk-node'
-import { eventHandler, fromNodeMiddleware } from 'h3'
+import { eventHandler, fromNodeMiddleware, getRequestProtocol } from 'h3'
 import type { H3Event, EventHandler, NodeMiddleware } from 'h3'
 import type { ClerkOptions, SignedInAuthObject, SignedOutAuthObject } from '@clerk/clerk-sdk-node'
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import type { ClerkOptions, SignedInAuthObject, SignedOutAuthObject } from '@cle
 
 // needed until https://github.com/nuxt/nuxt/issues/23348 is resolved
 const fixProtoHeaderInDevMode = (event: H3Event) => {
-  if (process.dev) {
+  if (process.env.NODE_ENV === 'development') {
     event.node.req.headers['x-forwarded-proto'] = getRequestProtocol(event)
   }
 }


### PR DESCRIPTION
closes https://github.com/wobsoriano/nuxt-clerk-template/issues/1

cause of infinite loop is that h3/nuxt are incorrectly setting the `x-forwarded-proto` header to `ipv4` which in turn breaks clerk. 

The fix is a temporary one and can be probably removed once [this nuxt issue](https://github.com/nuxt/nuxt/issues/23348) gets closed