### PR TITLE
Change `ClerkOptions` to `ClerkMiddlewareOptions`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { ClerkExpressWithAuth } from '@clerk/clerk-sdk-node'
 import { eventHandler, fromNodeMiddleware, getRequestProtocol } from 'h3'
 import type { EventHandler, H3Event, NodeMiddleware } from 'h3'
-import type { ClerkOptions, SignedInAuthObject, SignedOutAuthObject } from '@clerk/clerk-sdk-node'
+import type { ClerkMiddlewareOptions, SignedInAuthObject, SignedOutAuthObject } from '@clerk/clerk-sdk-node'
 
 // needed until https://github.com/nuxt/nuxt/issues/23348 is resolved
 function fixProtoHeaderInDevMode(event: H3Event) {
@@ -9,7 +9,7 @@ function fixProtoHeaderInDevMode(event: H3Event) {
     event.node.req.headers['x-forwarded-proto'] = getRequestProtocol(event)
 }
 
-export function withClerkMiddleware(options?: ClerkOptions) {
+export function withClerkMiddleware(options?: ClerkMiddlewareOptions) {
   return eventHandler({
     onRequest: [
       fixProtoHeaderInDevMode,
@@ -22,7 +22,7 @@ export function withClerkMiddleware(options?: ClerkOptions) {
   })
 }
 
-export function withClerkAuth(handler: EventHandler, options?: ClerkOptions) {
+export function withClerkAuth(handler: EventHandler, options?: ClerkMiddlewareOptions) {
   return eventHandler({
     onRequest: [
       fixProtoHeaderInDevMode,


### PR DESCRIPTION
Both the functions are typed to take `ClerkOptions` and the options but if you want `ClerkMiddlewareOptions`

the options are passed to [this function](https://github.com/clerkinc/javascript/blob/131c831f4e9a94bc10ce95e08e1d7854a394c12a/packages/sdk-node/src/clerkExpressRequireAuth.ts#L31) with isn't clear as the function [you are using](https://github.com/clerkinc/javascript/blob/131c831f4e9a94bc10ce95e08e1d7854a394c12a/packages/sdk-node/src/clerkClient.ts#L73) is typed as any 🤷  