### PR TITLE
feat: allow disabling hacky proto header in dev fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "h3": "^1.8.0"
   },
   "dependencies": {
-    "@clerk/backend": "^0.33.0",
+    "@clerk/backend": "^0.34.2",
     "@clerk/clerk-sdk-node": "4.12.19"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@clerk/backend": "^0.34.2",
-    "@clerk/clerk-sdk-node": "4.12.19"
+    "@clerk/clerk-sdk-node": "4.12.22"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^0.43.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,11 +6,11 @@ settings:
 
 dependencies:
   '@clerk/backend':
-    specifier: ^0.33.0
-    version: 0.33.0(react@18.2.0)
+    specifier: ^0.34.2
+    version: 0.34.2(react@18.2.0)
   '@clerk/clerk-sdk-node':
-    specifier: 4.12.19
-    version: 4.12.19(react@18.2.0)
+    specifier: 4.12.22
+    version: 4.12.22(react@18.2.0)
 
 devDependencies:
   '@antfu/eslint-config':
@@ -186,12 +186,12 @@ packages:
       js-tokens: 4.0.0
     dev: true
 
-  /@clerk/backend@0.33.0(react@18.2.0):
-    resolution: {integrity: sha512-bhUJn4hrgQOGcn9Baxuk8pcbXROYXmsuua1Juolxp+1mAVwImx4JDh4Y/pweYTgZGCT86MnJX1HJS9bncdP3Eg==}
+  /@clerk/backend@0.34.2(react@18.2.0):
+    resolution: {integrity: sha512-ouulkcT6kfbAPw3w0vbkl758KzQ2y9UUnuhRJ5dY3SPGNjJnpes1BNETLnA1O3llZVV5yYexluhee4XmFcwV3A==}
     engines: {node: '>=14'}
     dependencies:
-      '@clerk/shared': 1.0.2(react@18.2.0)
-      '@clerk/types': 3.57.1
+      '@clerk/shared': 1.1.1(react@18.2.0)
+      '@clerk/types': 3.58.0
       '@peculiar/webcrypto': 1.4.1
       '@types/node': 16.18.6
       cookie: 0.5.0
@@ -203,13 +203,13 @@ packages:
       - react
     dev: false
 
-  /@clerk/clerk-sdk-node@4.12.19(react@18.2.0):
-    resolution: {integrity: sha512-gJD8xcvBmhjNFnRNstHByIn7u1gKHpFTtPKzC3kPS/Hb1OEUogfLtI36E449EvG069WaJ2TwD02KWBUWzMK0zQ==}
+  /@clerk/clerk-sdk-node@4.12.22(react@18.2.0):
+    resolution: {integrity: sha512-O1PWDzmECO8VoGEZG8m2QYkJzDDMiUqTGsn73u3ki1V2bX24BeFokSKlsLgklgpVXUhSeKp8A8wBrDOOY2Qpew==}
     engines: {node: '>=14'}
     dependencies:
-      '@clerk/backend': 0.33.0(react@18.2.0)
-      '@clerk/shared': 1.0.2(react@18.2.0)
-      '@clerk/types': 3.57.1
+      '@clerk/backend': 0.34.2(react@18.2.0)
+      '@clerk/shared': 1.1.1(react@18.2.0)
+      '@clerk/types': 3.58.0
       '@types/cookies': 0.7.7
       '@types/express': 4.17.14
       '@types/node-fetch': 2.6.2
@@ -220,8 +220,8 @@ packages:
       - react
     dev: false
 
-  /@clerk/shared@1.0.2(react@18.2.0):
-    resolution: {integrity: sha512-Mf7F9lk43FC65jacqDsyxDvTmV4PI/aC7lGWyCQS+9RDvZ58ElELQ0ILVC/89cQQPL+nOWr+sa499O/U+fA6Gw==}
+  /@clerk/shared@1.1.1(react@18.2.0):
+    resolution: {integrity: sha512-pEzhalD1Yo/gGsOE2BQugVQTjlIl2aYmoeRld3BDXHRDV1jnk+yUE2CFOw6bojgFWN9sbeN/ph/47UWvvoCSOg==}
     peerDependencies:
       react: '>=16'
     peerDependenciesMeta:
@@ -234,8 +234,8 @@ packages:
       swr: 2.2.0(react@18.2.0)
     dev: false
 
-  /@clerk/types@3.57.1:
-    resolution: {integrity: sha512-x7eIEwEf3S/vvhBPt6gyojtiKInpM5EF03OUUib3eDwDvuSxAjf55K553yZkclbJ+LOLmIdonuSDaOrKvyhwKw==}
+  /@clerk/types@3.58.0:
+    resolution: {integrity: sha512-fIsvEM3nYQwViOuYxNVcwEl0WkXW6AdYpSghNBKfOge1kriSSHP++T5rRMJBXy6asl2AEydVlUBKx9drAzqKoA==}
     engines: {node: '>=14'}
     dependencies:
       csstype: 3.1.1
@@ -4240,7 +4240,7 @@ packages:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
     dependencies:
       hosted-git-info: 2.8.9
-      resolve: 1.22.3
+      resolve: 1.22.8
       semver: 5.7.1
       validate-npm-package-license: 3.0.4
     dev: true

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,10 +9,17 @@ function fixProtoHeaderInDevMode(event: H3Event) {
     event.node.req.headers['x-forwarded-proto'] = getRequestProtocol(event)
 }
 
-export function withClerkMiddleware(options?: ClerkMiddlewareOptions) {
+type H3ClerkMiddlewareOptions = ClerkMiddlewareOptions & {
+  /**
+   * Adjusts the `x-forwarded-proto` header in development mode to match the protocol of the request. Temporary hacky fix to https://github.com/nuxt/nuxt/issues/23348.
+   */
+  adjustProtoHeaderInDev?: boolean
+}
+
+export function withClerkMiddleware(options: H3ClerkMiddlewareOptions = { adjustProtoHeaderInDev: true }) {
   return eventHandler({
     onRequest: [
-      fixProtoHeaderInDevMode,
+      options.adjustProtoHeaderInDev ? fixProtoHeaderInDevMode : () => {},
       fromNodeMiddleware(ClerkExpressWithAuth(options) as NodeMiddleware),
     ],
     async handler(event) {
@@ -22,10 +29,10 @@ export function withClerkMiddleware(options?: ClerkMiddlewareOptions) {
   })
 }
 
-export function withClerkAuth(handler: EventHandler, options?: ClerkMiddlewareOptions) {
+export function withClerkAuth(handler: EventHandler, options: H3ClerkMiddlewareOptions = { adjustProtoHeaderInDev: true }) {
   return eventHandler({
     onRequest: [
-      fixProtoHeaderInDevMode,
+      options?.adjustProtoHeaderInDev ? fixProtoHeaderInDevMode : () => {},
       fromNodeMiddleware(ClerkExpressWithAuth(options) as NodeMiddleware),
     ],
     async handler(event) {


### PR DESCRIPTION
This pull request introduces an adjustProtoHeaderInDev option (defaulting to true), which allows enabling or disabling the "x-forwarded-proto" hacky fix for [this issue](https://github.com/nuxt/nuxt/issues/23348). The reason for adding this option is that it currently interferes with the built-in Nuxt composables such as `useFetch` and `useAsyncData`. Please refer to [this issue](https://github.com/wobsoriano/nuxt-clerk-template/issues/6) for more details.

Additionally, it's important to note a trade-off: Enabling it fixes the proto header issue, while disabling it may cause infinite reloads in development.