### PR TITLE
fix: h3 event to web request conversion

### DIFF
--- a/.changeset/new-walls-tan.md
+++ b/.changeset/new-walls-tan.md
@@ -1,0 +1,5 @@
+---
+"h3-clerk": patch
+---
+
+fix: h3 event to web request conversion

--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
     "h3": "^1.8.0"
   },
   "dependencies": {
-    "@clerk/backend": "^1.2.4",
-    "@clerk/shared": "^2.3.1"
+    "@clerk/backend": "^1.3.0"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^2.21.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@clerk/backend':
-        specifier: ^1.2.4
-        version: 1.2.4(react@18.3.1)
+        specifier: ^1.3.0
+        version: 1.3.0(react@18.3.1)
       '@clerk/shared':
         specifier: ^2.3.1
         version: 2.3.1(react@18.3.1)
@@ -202,8 +202,8 @@ packages:
     bundledDependencies:
       - is-unicode-supported
 
-  '@clerk/backend@1.2.4':
-    resolution: {integrity: sha512-H6K1kHPaDFM6pBdwDAHh1jWSZxCWhGPzDmqgc7LByjqKS6RZUf3cs5mJkIXyopUpHY7wvwj50vSF0xJ46MEzNA==}
+  '@clerk/backend@1.3.0':
+    resolution: {integrity: sha512-WBVQqUgjo8itXQmB9j4vS+6EU4fsEskF1Bof4QMlXiyLazkhkqrlk1HVyDm0iQ3n4PJDkL4wN3IfJo2sBcauFQ==}
     engines: {node: '>=18.17.0'}
 
   '@clerk/shared@2.3.1':
@@ -218,8 +218,24 @@ packages:
       react-dom:
         optional: true
 
+  '@clerk/shared@2.3.2':
+    resolution: {integrity: sha512-uOTYqSmxe41Ye8TnyPtthwLp5rrYK5Ze04bvl1SQzlIibr4qeLU2DXZOYibMnSWvIMwr45pXUHsJh8NfKKIZ2w==}
+    engines: {node: '>=18.17.0'}
+    peerDependencies:
+      react: '>=18 || >=19.0.0-beta'
+      react-dom: '>=18 || >=19.0.0-beta'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   '@clerk/types@4.6.1':
     resolution: {integrity: sha512-QFeNKPYDmTJ88l5QYG0SPwbABk42wRMalW3M/wAtr+wnQxBCXyX2XRZe9h4g2rH1VF+wG4Xe56abeeD+xE4iEw==}
+    engines: {node: '>=18.17.0'}
+
+  '@clerk/types@4.7.0':
+    resolution: {integrity: sha512-Gg4zEZLE7wgByMhgHMU69tkIEwfiFKNSbtRwdtAwrW+Pg0blpVpw7XuN0wHNAYFM2COrrKEUaGt8KWZmmdTFbg==}
     engines: {node: '>=18.17.0'}
 
   '@es-joy/jsdoccomment@0.43.1':
@@ -3468,10 +3484,10 @@ snapshots:
       picocolors: 1.0.1
       sisteransi: 1.0.5
 
-  '@clerk/backend@1.2.4(react@18.3.1)':
+  '@clerk/backend@1.3.0(react@18.3.1)':
     dependencies:
-      '@clerk/shared': 2.3.1(react@18.3.1)
-      '@clerk/types': 4.6.1
+      '@clerk/shared': 2.3.2(react@18.3.1)
+      '@clerk/types': 4.7.0
       cookie: 0.5.0
       snakecase-keys: 5.4.4
       tslib: 2.4.1
@@ -3489,7 +3505,21 @@ snapshots:
     optionalDependencies:
       react: 18.3.1
 
+  '@clerk/shared@2.3.2(react@18.3.1)':
+    dependencies:
+      '@clerk/types': 4.7.0
+      glob-to-regexp: 0.4.1
+      js-cookie: 3.0.5
+      std-env: 3.7.0
+      swr: 2.2.5(react@18.3.1)
+    optionalDependencies:
+      react: 18.3.1
+
   '@clerk/types@4.6.1':
+    dependencies:
+      csstype: 3.1.1
+
+  '@clerk/types@4.7.0':
     dependencies:
       csstype: 3.1.1
 
@@ -4470,7 +4500,7 @@ snapshots:
   dot-case@3.0.4:
     dependencies:
       no-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.6.3
 
   eastasianwidth@0.2.0: {}
 
@@ -5509,7 +5539,7 @@ snapshots:
 
   lower-case@2.0.2:
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.6.3
 
   lru-cache@10.3.0: {}
 
@@ -5610,7 +5640,7 @@ snapshots:
   no-case@3.0.4:
     dependencies:
       lower-case: 2.0.2
-      tslib: 2.4.1
+      tslib: 2.6.3
 
   node-fetch-native@1.6.4: {}
 
@@ -6035,7 +6065,7 @@ snapshots:
   snake-case@3.0.4:
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.6.3
 
   snakecase-keys@5.4.4:
     dependencies:

--- a/src/__tests__/withClerkMiddleware.test.ts
+++ b/src/__tests__/withClerkMiddleware.test.ts
@@ -1,5 +1,5 @@
 import type { App } from 'h3'
-import { createApp, eventHandler, toNodeListener } from 'h3'
+import { createApp, eventHandler, getQuery, readBody, toNodeListener } from 'h3'
 import type { Test } from 'supertest'
 import supertest from 'supertest'
 import type TestAgent from 'supertest/lib/agent'
@@ -140,5 +140,29 @@ describe('withClerkMiddleware(options)', () => {
         secretKey: 'TEST_SECRET_KEY',
       }),
     )
+  })
+
+  it('should not have problems with h3 utils', async () => {
+    authenticateRequestMock.mockResolvedValueOnce({
+      headers: new Headers(),
+      toAuth: () => 'mockedAuth',
+    })
+
+    app.use('/post', eventHandler(async (event) => {
+      const body = await readBody(event)
+      const query = getQuery(event)
+      return { body, query }
+    }))
+
+    const result = await request.post('/post').send({ user: 'john' }).query({ id: '123' })
+    expect(result.statusCode).toBe(200)
+    expect(result.body).toEqual({
+      body: {
+        user: 'john',
+      },
+      query: {
+        id: '123',
+      }
+    })
   })
 })

--- a/src/__tests__/withClerkMiddleware.test.ts
+++ b/src/__tests__/withClerkMiddleware.test.ts
@@ -162,7 +162,7 @@ describe('withClerkMiddleware(options)', () => {
       },
       query: {
         id: '123',
-      }
+      },
     })
   })
 })

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,10 +1,9 @@
 import { constants } from '@clerk/backend/internal'
-import { apiUrlFromPublishableKey } from '@clerk/shared/apiUrlFromPublishableKey'
 
 export const API_VERSION = process.env.CLERK_API_VERSION || 'v1'
 export const SECRET_KEY = process.env.CLERK_SECRET_KEY || ''
 export const PUBLISHABLE_KEY = process.env.CLERK_PUBLISHABLE_KEY || ''
-export const API_URL = process.env.CLERK_API_URL || apiUrlFromPublishableKey(PUBLISHABLE_KEY)
+export const API_URL = process.env.CLERK_API_URL
 export const JWT_KEY = process.env.CLERK_JWT_KEY || ''
 // export const SDK_METADATA = {
 //   name: PACKAGE_NAME,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,12 @@
+import type { H3Event } from 'h3'
+import { getRequestHeaders, getRequestProtocol } from 'h3'
+
+export function toWebRequest(event: H3Event) {
+  const headers = getRequestHeaders(event) as HeadersInit
+  const protocol = getRequestProtocol(event)
+  const dummyOriginReqUrl = new URL(event.node.req.url || '', `${protocol}://clerk-dummy`)
+  return new Request(dummyOriginReqUrl, {
+    method: event.method,
+    headers: new Headers(headers),
+  })
+}

--- a/src/withClerkMiddleware.ts
+++ b/src/withClerkMiddleware.ts
@@ -1,20 +1,10 @@
 import type { ClerkOptions } from '@clerk/backend'
-import type { H3Event } from 'h3'
-import { eventHandler, getRequestHeaders, getRequestProtocol, setResponseHeader } from 'h3'
+import { eventHandler, setResponseHeader } from 'h3'
 import { AuthStatus, type SignedInAuthObject, type SignedOutAuthObject } from '@clerk/backend/internal'
+import { toWebRequest } from './utils'
 import { clerkClient } from './clerkClient'
 import * as constants from './constants'
 import { handshakeWithoutRedirect } from './errors'
-
-function toWebRequest(event: H3Event) {
-  const headers = getRequestHeaders(event) as HeadersInit
-  const protocol = getRequestProtocol(event)
-  const dummyOriginReqUrl = new URL(event.node.req.url || '', `${protocol}://clerk-dummy`)
-  return new Request(dummyOriginReqUrl, {
-    method: event.method,
-    headers: new Headers(headers),
-  })
-}
 
 export function withClerkMiddleware(options?: ClerkOptions) {
   return eventHandler(async (event) => {

--- a/src/withClerkMiddleware.ts
+++ b/src/withClerkMiddleware.ts
@@ -1,9 +1,20 @@
 import type { ClerkOptions } from '@clerk/backend'
-import { eventHandler, setResponseHeader, toWebRequest } from 'h3'
+import type { H3Event } from 'h3'
+import { eventHandler, getRequestHeaders, getRequestProtocol, setResponseHeader } from 'h3'
 import { AuthStatus, type SignedInAuthObject, type SignedOutAuthObject } from '@clerk/backend/internal'
 import { clerkClient } from './clerkClient'
 import * as constants from './constants'
 import { handshakeWithoutRedirect } from './errors'
+
+function toWebRequest(event: H3Event) {
+  const headers = getRequestHeaders(event) as HeadersInit
+  const protocol = getRequestProtocol(event)
+  const dummyOriginReqUrl = new URL(event.node.req.url || '', `${protocol}://clerk-dummy`)
+  return new Request(dummyOriginReqUrl, {
+    method: event.method,
+    headers: new Headers(headers),
+  })
+}
 
 export function withClerkMiddleware(options?: ClerkOptions) {
   return eventHandler(async (event) => {


### PR DESCRIPTION
This PR fixes an issue where h3 utils like `readBody` hangs when the clerk middleware is installed.